### PR TITLE
implemented filesize compression for jSkin and gSkin

### DIFF
--- a/scripts/mgear/core/attribute.py
+++ b/scripts/mgear/core/attribute.py
@@ -292,7 +292,7 @@ def moveChannel(attr, sourceNode, targetNode, duplicatedPolicy=None):
                           " source: {}".format(attr, sourceNode.name()))
         return
     atType = at.type()
-    if atType in ["double", "enum"]:
+    if atType in ["double", "float", "enum"]:
 
         newAtt = None
         attrName = attr
@@ -324,7 +324,7 @@ def moveChannel(attr, sourceNode, targetNode, duplicatedPolicy=None):
         if not newAtt:
             # get the attr data
             value = at.get()
-            if atType == "double":
+            if atType in ["double", "float"]:
                 kwargs = {}
                 min = at.getMin()
                 if min:
@@ -342,11 +342,11 @@ def moveChannel(attr, sourceNode, targetNode, duplicatedPolicy=None):
             pm.deleteAttr(at)
 
             # rebuild the attr
-            if atType == "double":
+            if atType in ["double", "float"]:
                 pm.addAttr(targetNode,
                            ln=attrName,
                            niceName=nName,
-                           at="double",
+                           at=atType,
                            dv=value,
                            k=True,
                            **kwargs)

--- a/scripts/mgear/core/callbackManager.py
+++ b/scripts/mgear/core/callbackManager.py
@@ -326,7 +326,7 @@ class UserTimeChangedManager(object):
     def userTimeChanged(self, *args):
         """Check if playback is active, if so return without calling func
         """
-        if om.MConditionMessage.getConditionState("playingBack"):
+        if om.MConditionMessage.getConditionState("playingBackAuto"):
             return
         self.func(*args)
 

--- a/scripts/mgear/core/skin.py
+++ b/scripts/mgear/core/skin.py
@@ -313,7 +313,7 @@ def setInfluenceWeights(skinCls, dagPath, components, dataDic, compressed):
                 if compressed:
                     for jj in range(numComponentsPerInfluence):
                         # json keys can't be integers. The vtx number key
-                        # is a string. example: vtx[35] would be: "35": 0.6974,
+                        # is unicode. example: vtx[35] would be: u"35": 0.6974,
                         # But the binary format is still an int, so check both.
                         # if the key doesn't exist, set it to 0.0
                         wt = wtValues.get(jj) or wtValues.get(str(jj)) or 0.0
@@ -340,11 +340,11 @@ def setBlendWeights(skinCls, dagPath, components, dataDic, compressed):
     if compressed:
         # The compressed format skips 0.0 weights. If the key is empty,
         # set it to 0.0. JSON keys can't be integers. The vtx number key
-        # is a string. example: vtx[35] would be: "35": 0.6974,
+        # is unicode. example: vtx[35] would be: u"35": 0.6974,
         # But the binary format is still an int, so check the key type.
         blendWeights = OpenMaya.MDoubleArray(dataDic['vertexCount'])
         for key, value in dataDic['blendWeights'].items():
-            if isinstance(key, str):
+            if isinstance(key, basestring):
                 blendWeights.set(value, int(key))
             if isinstance(key, int):
                 blendWeights.set(value, key)

--- a/scripts/mgear/core/skin.py
+++ b/scripts/mgear/core/skin.py
@@ -341,13 +341,10 @@ def setBlendWeights(skinCls, dagPath, components, dataDic, compressed):
         # The compressed format skips 0.0 weights. If the key is empty,
         # set it to 0.0. JSON keys can't be integers. The vtx number key
         # is unicode. example: vtx[35] would be: u"35": 0.6974,
-        # But the binary format is still an int, so check the key type.
+        # But the binary format is still an int, so cast the key to int.
         blendWeights = OpenMaya.MDoubleArray(dataDic['vertexCount'])
         for key, value in dataDic['blendWeights'].items():
-            if isinstance(key, basestring):
                 blendWeights.set(value, int(key))
-            if isinstance(key, int):
-                blendWeights.set(value, key)
     else:
         # The original weight format was a full list for every vertex
         # For backwards compatibility on older skin files:


### PR DESCRIPTION
Instead of a list of weights, it is now a dictionary of weights, with the vertex number as key. 0.0 weights are omitted from the data to save space. This can reduce the file size dramatically down to 3% of the size! When importing the missing keys, 0.0 skin weight is assumed.

Tested for backwards compatibility. This new functionality will still properly import older gSkin and jSkin files.

I made jSkin the default choice in the import and export fileDialog. Now that the file sizes are smaller, I believe jSkin is a superior choice, to give TDs the ability to edit the files directly.

Also updated to modern string formatting. And put all errors and warnings on single lines, instead of multi-line strings, for better readability.