### PR TITLE
SDK manager ui fix

### DIFF
--- a/scripts/mgear/core/pyqt.py
+++ b/scripts/mgear/core/pyqt.py
@@ -156,6 +156,7 @@ def showDialog(dialog, dInst=True, dockable=False, *args):
         control = windw.toolName + "WorkspaceControl"
         if pm.workspaceControl(control, q=True, exists=True):
             pm.workspaceControl(control, e=True, close=True)
+        if pm.workspaceControl(control, q=True, exists=True):
             pm.deleteUI(control, control=True)
     desktop = QtWidgets.QApplication.desktop()
     screen = desktop.screen()


### PR DESCRIPTION
# The problem
Calling pm.deleteUI after using pm.workspaceControl to close the UI causes an issue with SDK manager window as the workspaceControl command already closes the ui.

# Solution
Check that the ui is still in existence before calling pm.deleteUI