### PR TITLE
When copy skin, match the skinningMethod as well

### DIFF
--- a/scripts/mgear/core/skin.py
+++ b/scripts/mgear/core/skin.py
@@ -550,6 +550,7 @@ def skinCopy(sourceMesh=None, targetMesh=None, *args):
         ss = getSkinCluster(sourceMesh)
 
         if ss:
+            skinMethod = ss.skinningMethod.get()
             oDef = pm.skinCluster(sourceMesh, query=True, influence=True)
             skinCluster = pm.skinCluster(oDef,
                                          targetMesh,
@@ -562,6 +563,7 @@ def skinCopy(sourceMesh=None, targetMesh=None, *args):
                                ia="oneToOne",
                                sm=True,
                                nr=True)
+            skinCluster.skinningMethod.set(skinMethod)
         else:
             errorMsg = "Source Mesh : {} doesn't have a skinCluster."
             pm.displayError(errorMsg.format(sourceMesh.name()))


### PR DESCRIPTION
As mentioned here http://forum.mgear-framework.com/t/tip-when-copying-skinning-make-sure-to-change-skincluster-skinning-method/1333
The Copy Skin function wasn't matching the skinning method to the source geometry.