### PR TITLE
strip pipes from skinCluster names

### DIFF
--- a/scripts/mgear/core/skin.py
+++ b/scripts/mgear/core/skin.py
@@ -482,8 +482,10 @@ def importSkin(filePath=None, *args):
             else:
                 try:
                     joints = data['weights'].keys()
+                    # strip | from longName, or skinCluster command may fail.
+                    skinName = data['skinClsName'].replace('|','')
                     skinCluster = pm.skinCluster(
-                        joints, objNode, tsb=True, nw=2, n=data['skinClsName'])
+                        joints, objNode, tsb=True, nw=2, n=skinName)
                 except Exception:
                     sceneJoints = set([pm.PyNode(x).name()
                                        for x in pm.ls(type='joint')])
@@ -553,17 +555,19 @@ def skinCopy(sourceMesh=None, targetMesh=None, *args):
         if ss:
             skinMethod = ss.skinningMethod.get()
             oDef = pm.skinCluster(sourceMesh, query=True, influence=True)
+            # strip | from longName, or skinCluster command may fail.
+            skinName = targetMesh.name().replace('|','') + "_SkinCluster"
             skinCluster = pm.skinCluster(oDef,
                                          targetMesh,
                                          tsb=True,
                                          nw=1,
                                          n=targetMesh.name() + "_SkinCluster")
-            pm.copySkinWeights(ss=ss.stripNamespace(),
-                               ds=skinCluster.name(),
+            pm.copySkinWeights(sourceSkin=ss.stripNamespace(),
+                               destinationSkin=skinCluster.name(),
                                noMirror=True,
-                               ia="oneToOne",
-                               sm=True,
-                               nr=True)
+                               influenceAssociation="oneToOne",
+                               smooth=True,
+                               normalize=True)
             skinCluster.skinningMethod.set(skinMethod)
         else:
             errorMsg = "Source Mesh : {} doesn't have a skinCluster."


### PR DESCRIPTION
There is a bug if you have non-unique names in your geo. Your node names change to longNames, and the pm.skinCluster command will not accept a name flag that has pipes in it.

You end up with "Invalid deformer name was specified." errors from Maya. Stripping the pipes from the skinCluster name appears to fix this bug.

This fixes the bug on the skinCluster name only. So skinCopy() and importSkin() are fixed. But I do not know if this has any additional bugs related to pipe characters in the filenames of the jSkin or gSkin files. I do know that longNames with pipes work as filenames on MacOS and Linux. I do not know about Windows.