### PR TITLE
Dynamic Settings.ui creation.  Simpler AddChain method for non planar chains, Joint based spline deformation opperator

### DIFF
--- a/scripts/mgear/core/primitive.py
+++ b/scripts/mgear/core/primitive.py
@@ -226,6 +226,49 @@ def add2DChain2(parent, name, positions, normal, negate=False, vis=True):
 
     return chain
 
+def add2DChainNonPlanar(parent, name, positions, normal, negate=False, vis=True):
+
+    """Create a 2D joint chain. Like Softimage 2D chain.
+
+    Arguments:
+        parent (dagNode): The parent for the chain.
+        name (str): The node name.
+        positions(list of vectors): the positons to define the chain.
+        normal (vector): The normal vector to define the direction of
+            the chain.
+        negate (bool): If True will negate the direction of the chain
+
+    Returns;
+        list of dagNodes: The list containg all the joints of the chain
+
+    >>> self.rollRef = pri.add2DChain(
+        self.root,
+        self.getName("rollChain"),
+        self.guide.apos[:2],
+        self.normal,
+        self.negate)
+
+    """
+    if "%s" not in name:
+        name += "%s"
+
+    transforms = transform.getChainTransform(positions, normal, negate)
+    t = transform.setMatrixPosition(transforms[-1], positions[-1])
+    transforms.append(t)
+
+    chain = []
+    for i, t in enumerate(transforms):
+        node = addJoint(parent, name % i, t, vis)
+        chain.append(node)
+        parent = node
+
+    # moving rotation value to joint orient
+    for i, jnt in enumerate(chain):
+        if i == 0:
+            pm.makeIdentity(jnt, apply=1, t=0, r=1, s=0, n=0, pn=1)
+        jnt.setAttr("radius", 1.5)
+
+    return chain
 
 def add2DChain(parent, name, positions, normal, negate=False, vis=True):
     """Create a 2D joint chain. Like Softimage 2D chain.


### PR DESCRIPTION
This has changes in code that I've made to get over a bug whereby the settings.py file for a component wouldn't be converted to a pyc file when imported by the component.  I don't think it's happy with the relative import so the puthon module[settingsUI] namespace it used from the last imported file.  This dynamic what of loading the .ui files has always worked well for me, not cost anything as far as I can see.

I've added a simpler addChainNonPlanar method so that the work of clearing the joint orients is done by makeIdentity after the joint has be placed in the normal mgear manor.  As it's the guides design to lock joints into a plane, or let the user unlock them if desired, I don't see why the already existing method it so strict and it also can ause flipping issues as discussed on the forum to do with the leg_3jnt component flipping.

I've also added methods to enable my the create a FK Spine based on guide locations.

I've kept the new components that use these out of this pull request.  I'll upload a sep repro for these components